### PR TITLE
后台常驻问题

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,9 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+
 
     <queries>
         <intent>
@@ -44,6 +47,13 @@
             <meta-data
                 android:name="android.accessibilityservice"
                 android:resource="@xml/accessibility_service_config" />
+        </service>
+        <!--        ["connectedDevice" | "dataSync" | "location" | "mediaPlayback" | "mediaProjection" | "phoneCall"]-->
+        <service
+            android:name=".ForeGroundService"
+            android:foregroundServiceType="dataSync"
+            android:enabled="true"
+            >
         </service>
 
         <receiver

--- a/app/src/main/java/com/zfdang/touchhelper/ForeGroundService.java
+++ b/app/src/main/java/com/zfdang/touchhelper/ForeGroundService.java
@@ -1,0 +1,73 @@
+package com.zfdang.touchhelper;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+
+public class ForeGroundService extends Service {
+  private static final String TAG = ForeGroundService.class.getSimpleName();
+  NotificationManager notificationManager;
+  String notificationId = "touch";
+  String notificationName = "常驻服务";
+
+  private void startForegroundService() {
+    notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+    //创建 NotificationChannel
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      NotificationChannel channel = new NotificationChannel(notificationId, notificationName, NotificationManager.IMPORTANCE_HIGH);
+      notificationManager.createNotificationChannel(channel);
+    }
+    startForeground(1, getNotification());
+
+  }
+
+  private Notification getNotification() {
+    Notification.Builder builder = new Notification.Builder(this)
+        .setSmallIcon(R.drawable.ic_touch_helper_icon)
+        .setContentTitle(getString(R.string.app_name))
+        .setContentText(getString(R.string.app_name) + "正在运行...");
+
+    //设置Notification的ChannelID,否则不能正常显示        
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      builder.setChannelId(notificationId);
+    }
+    Notification notification = builder.build();
+    return notification;
+
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    startForegroundService();
+    Log.d(TAG, "onCreate()");
+  }
+
+
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    Log.d(TAG, "onStartCommand()");
+    return super.onStartCommand(intent, flags, startId);
+  }
+
+
+  @Override
+  public void onDestroy() {
+    Log.d(TAG, "onDestroy()");
+    stopForeground(true);// 停止前台服务--参数：表示是否移除之前的通知
+    super.onDestroy();
+  }
+
+  @Override
+  public IBinder onBind(Intent intent) {
+    Log.d(TAG, "onBind()");
+    // TODO: Return the communication channel to the service.
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+}

--- a/app/src/main/java/com/zfdang/touchhelper/MainActivity.java
+++ b/app/src/main/java/com/zfdang/touchhelper/MainActivity.java
@@ -1,5 +1,6 @@
 package com.zfdang.touchhelper;
 
+import android.content.Intent;
 import android.os.Bundle;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
@@ -26,6 +27,8 @@ public class MainActivity extends AppCompatActivity {
         NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment);
         NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
         NavigationUI.setupWithNavController(navView, navController);
+//        Log.d(MainActivity.class.getSimpleName(), "onStartCommand()");
+        startForegroundService(new Intent(getApplicationContext(), ForeGroundService.class));
     }
 
 }


### PR DESCRIPTION
使用 honor 20 pro + 鸿蒙系统时，即便后台锁定、自动启动、关闭电量优化等都已经做了，还是有时候会退出程序。

所以想加一个常驻通知栏做到保活。

我照网上搜索，添加了一个[提交](https://github.com/walk143/Android-Touch-Helper/commit/f8681cd3c36ddb0f0a69d3bc6e49604bee04574e)。

> 前台常驻做成一个开关选项比较好，但我还刚接触安卓开发，实现不了。