### PR TITLE
支持关闭应用后台保活

### DIFF
--- a/app/src/main/java/com/zfdang/touchhelper/TouchHelperService.java
+++ b/app/src/main/java/com/zfdang/touchhelper/TouchHelperService.java
@@ -45,6 +45,8 @@ public class TouchHelperService extends AccessibilityService {
         if (serviceImpl != null) {
             serviceImpl.onInterrupt();
         }
+        Intent restartIntent = new Intent(this, TouchHelperService.class);
+        startService(restartIntent);
     }
 
     @Override


### PR DESCRIPTION
TouchHelperService被杀死后重启启动，保活该AccessibilityService。
使用华为mate30pro自测，杀死应用后台后，依旧可以正常跳过开屏广告。